### PR TITLE
Improve performance

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -541,7 +541,14 @@ var frontend = {
 		f.coursesUl.find("li").knubtip("enable");
 	},
 	/* called when user drag'n'dropped something */
-	update: function() {
+	update: function(event, ui) {
+		// catches the first of two duplicate calls to the update function
+		// after every drag and drop and returns, so that the rules are
+		// only checked once per change
+		// ui.sender is only defined for the second call
+		if (ui.sender === null) {
+			return;
+		}
 		f.adjustSemesterViewHeight();
 		f.sortPool();
 		f.filterManager.filter();

--- a/js/helper.js
+++ b/js/helper.js
@@ -57,11 +57,16 @@ Array.cartesianProduct = function () {
 };
 
 
-// Not the best implementation, because [1, 2, 1].subsetOf([1, 2, 3]) is true, but enough for what we need.
-Array.prototype.subsetOf = function (other) {
+// specifically for arrays sorted using the same order
+Array.prototype.subsetOfSorted = function (other) {
+	var j = 0;
 	for (var i = 0; i < this.length; i += 1) {
-		if (other.indexOf(this[i]) === -1)
-			return false;
+		while (this[i] !== other[j]) {
+			++j;
+			if (j >= other.length) {
+				return false
+			}
+		}
 	}
 	return true;
 };

--- a/js/logic.js
+++ b/js/logic.js
@@ -488,6 +488,7 @@ var vertiefungsgebieteRule = {
 			var unique = true;
 
 			var combStrArray = combination.map(combToStringArray);
+			combStrArray.sort();
 
 			// cache data to improve performance
 			combination.vertiefungsstring = vertiefungsstring;

--- a/js/logic.js
+++ b/js/logic.js
@@ -500,12 +500,12 @@ var vertiefungsgebieteRule = {
 					// decide whether it is worthy to override the old value
 					alreadyIn = true;
 					// it IS worthy, when it is longer than the old value and is a superset of it
-					if (combinationOld.length < combination.length && combinationOld.strArray.subsetOf(combStrArray)) {
+					if (combinationOld.length < combination.length && combinationOld.strArray.subsetOfSorted(combStrArray)) {
 						mergedCombinations[helpindex] = combination;
 						unique = false;
 					}
 					else {
-						if (combStrArray.subsetOf(combinationOld.strArray) === true)
+						if (combStrArray.subsetOfSorted(combinationOld.strArray) === true)
 							unique = false;
 					}
 				}

--- a/js/logic.js
+++ b/js/logic.js
@@ -488,20 +488,24 @@ var vertiefungsgebieteRule = {
 			var unique = true;
 
 			var combStrArray = combination.map(combToStringArray);
+
+			// cache data to improve performance
+			combination.vertiefungsstring = vertiefungsstring;
+			combination.strArray = combStrArray;
+
 			// Walk through all combinations and then decide, whether to save it in the array.
 			mergedCombinations.forEach(function(combinationOld, helpindex) {
-				var combOldStrArray = combinationOld.map(combToStringArray);
 				// if the Vertiefung pair is already in the array ..
-				if (combinationOld.vertiefungPair.join("") === vertiefungsstring) {
+				if (combinationOld.vertiefungsstring === vertiefungsstring) {
 					// decide whether it is worthy to override the old value
 					alreadyIn = true;
 					// it IS worthy, when it is longer than the old value and is a superset of it
-					if (combinationOld.length < combination.length && combOldStrArray.subsetOf(combStrArray)) {
+					if (combinationOld.length < combination.length && combinationOld.strArray.subsetOf(combStrArray)) {
 						mergedCombinations[helpindex] = combination;
 						unique = false;
 					}
 					else {
-						if (combStrArray.subsetOf(combOldStrArray) === true)
+						if (combStrArray.subsetOf(combinationOld.strArray) === true)
 							unique = false;
 					}
 				}


### PR DESCRIPTION
Checking the rules for Vertiefungsgebiete gets very slow, if a lot of them are selected. These changes should improve the situation (tested them in Chrome and Firefox). I got a performance increase of about 10x for simple rule checking and 20x for rule checking after drag and drop.